### PR TITLE
Fix database migration & filter issue

### DIFF
--- a/app/Category.php
+++ b/app/Category.php
@@ -7,12 +7,14 @@ use Illuminate\Database\Eloquent\Model;
 class Category extends Model
 {
     public function posts()
-    {
-        
+    { 
         return $this->hasMany(Post::class);
 
     }
 
     
-
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
 }

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -25,14 +25,14 @@ class BlogController extends Controller
     	return view("blog.index", compact('posts', 'categories'));
     }
 
-    public function category($id)
+    public function category(Category $category)
     {
         $categories = Category::with('posts')->orderBy('title', 'asc')->get();
 
-    	$posts = Post::with('author')
+        $posts = $category->posts()
+                        ->with('author')
                         ->latestFirst()
-                        ->where('category_id', $id)
-    			->paginate(8);
+    			        ->paginate(8);
 
     	return view("blog.index", compact('posts', 'categories'));
     }

--- a/database/migrations/2019_04_27_112428_create_posts_table.php
+++ b/database/migrations/2019_04_27_112428_create_posts_table.php
@@ -16,7 +16,7 @@ class CreatePostsTable extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->integer('author_id')->unsigned();
+            $table->bigInteger('author_id')->unsigned();
             $table->foreign('author_id')->references('id')->on('users')->onDelete('restrict');
             $table->string('title');
             $table->string('slug')->unique();
@@ -24,8 +24,8 @@ class CreatePostsTable extends Migration
             $table->text('body');
             $table->string('image')->nullable();
             $table->timestamps();
-            $table->timestamp('published_at')->nullable();;
-            $table->timestamp('category_id')->nullable();
+            // $table->timestamp('published_at')->nullable();;
+            // $table->timestamp('category_id')->nullable();
         });
     }
 

--- a/database/migrations/2019_04_29_144717_alter_posts_add_category_id_column.php
+++ b/database/migrations/2019_04_29_144717_alter_posts_add_category_id_column.php
@@ -14,7 +14,7 @@ class AlterPostsAddCategoryIdColumn extends Migration
     public function up()
     {
         Schema::table('posts', function (Blueprint $table) {
-            $table->integer('category_id')->nullable();
+            $table->bigInteger('category_id')->unsigned()->nullable();
             $table->foreign('category_id')->references('id')->on('categories')->onDelete('restrict');
 
         });


### PR DESCRIPTION
Since Laravel version 5.8 the default id is in bigIncrements which will generate UNSIGNED BIG INTEGER. So if you need to make foreign key you also need to make it as: `bigInteger('column')->unsigned()` or `unsignedBigInteger()`